### PR TITLE
fix: add rel=me to mastodon

### DIFF
--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -197,17 +197,17 @@
       <div class="container py-5 d-flex align-items-center justify-content-center" style="min-height: 100vh">
         <div class="my-5 text-center">
           <p class="display-4 font-weight-bold font-ptsn mb-5">
-            <span class="">Create.</span> 
+            <span class="">Create.</span>
             <span class="text-muted">Share. </span>
             <span style="color:#a0aec0">Discover.</span>
           </p>
           <p class="display-4 font-weight-bold font-ptsn mb-5">
-            <span class="">Collect.</span> 
+            <span class="">Collect.</span>
             <span class="text-muted">Follow. </span>
             <span style="color:#a0aec0">Explore.</span>
           </p>
           <p class="display-4 font-weight-bold font-ptsn mb-5">
-            <span class="">Curate.</span> 
+            <span class="">Curate.</span>
             <span class="text-muted">Comment. </span>
             <span style="color:#a0aec0">Like.</span>
           </p>
@@ -300,7 +300,7 @@
           <ul class="list-unstyled text-small">
             <li><a class="text-muted" href="https://write.as/pixelfed" rel="nofollow">Blog</a></li>
             <li><a class="text-muted" href="https://docs.pixelfed.org">Documentation</a></li>
-            <li><a class="text-muted" href="https://mastodon.social/@Pixelfed" rel="nofollow noreferrer noopener">Mastodon</a></li>
+            <li><a class="text-muted" href="https://mastodon.social/@Pixelfed" rel="nofollow noreferrer noopener me">Mastodon</a></li>
             <li><a class="text-muted" href="https://twitter.com/@Pixelfed" rel="nofollow noreferrer noopener">Twitter</a></li>
           </ul>
         </div>


### PR DESCRIPTION
Minor pet peeve, but on Mastodon your site isn't verified because it doesn't have `rel="me"` in the HTML.

![image](https://user-images.githubusercontent.com/22801583/132128298-50056ebe-877d-41c9-96db-fb45f14954ae.png)

> If you put a link in your profile metadata, Mastodon checks if the linked page links back to your Mastodon profile. If so, you get a verification checkmark next to that link, since you are confirmed as the owner.
> 
> Behind the scenes, Mastodon checks for the `rel="me"` attribute on the link back. Likewise, Mastodon puts `rel="me"` on the links within profile metadata.
> — https://docs.joinmastodon.org/user/profile/

After this, it should display it as a verified link. That way users don't have to manually check the website to ensure this is the official account on Mastodon.

![image](https://user-images.githubusercontent.com/22801583/132126392-ddc28ae3-4a95-4f4b-91a0-cf6b4b136e68.png)
